### PR TITLE
Prevent kernel from being updated

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -33,7 +33,7 @@ export VAULT_WEB_PORT="8200"
 export VAULTUI_WEB_PORT="8100"
 
 # Run updates & install packages
-sudo yum update -y
+sudo yum update --exclude=kernel* -y
 sudo yum check-update
 sudo yum install bind-utils git mysql mlocate net-tools ntp telnet unzip yum-utils wget -y
 


### PR DESCRIPTION
adds --exclude=kernel* to yum update command - otherwise installing virtualbox Guest Additions will fail - complains that it cannot find the source of the current kernel.

However, the error message that will be given is about shared folders:

```
Vagrant was unable to mount VirtualBox shared folders. This is usually
because the filesystem "vboxsf" is not available. This filesystem is
made available via the VirtualBox Guest Additions and kernel module.
Please verify that these guest additions are properly installed in the
guest. This is not a bug in Vagrant and is usually caused by a faulty
Vagrant box. For context, the command attempted was:

mount -t vboxsf -o uid=1000,gid=1000 vagrant /vagrant

The error output from the command was:

/sbin/mount.vboxsf: mounting failed with the error: No such device
```

If you dig deeper you will find that /var/log/vboxadd-install.log says the following:

```
/tmp/vbox.0/Makefile.include.header:97: *** Error: unable to find the sources of your current Linux kernel. Specify KERN_DIR=<directory> and run Make again.  Stop.
```

This is caused by updating the kernel. Not sure if there is another fix that will allow updating the kernel and still allow guest additions to work, but this fix is what got things working on my machine.